### PR TITLE
fix(ctftime): ctftime callback params

### DIFF
--- a/packages/client/src/routes/ctftime-callback.js
+++ b/packages/client/src/routes/ctftime-callback.js
@@ -2,11 +2,12 @@ import { Component } from 'preact'
 
 export default class CtftimeCallback extends Component {
   componentDidMount() {
+    const params = new URLSearchParams(location.search)
     window.opener.postMessage(
       {
         kind: 'ctftimeCallback',
-        state: this.props.state,
-        ctftimeCode: this.props.code,
+        state: params.get('state'),
+        ctftimeCode: params.get('code'),
       },
       location.origin
     )


### PR DESCRIPTION
Ever since the client was rewritten its not mapping the url params